### PR TITLE
Feat/add channel selection

### DIFF
--- a/src/experiments/run_generation_experiment.py
+++ b/src/experiments/run_generation_experiment.py
@@ -5,10 +5,12 @@ import base64
 import asyncio
 import aiohttp
 import requests
+import io
 from pathlib import Path
 from dotenv import load_dotenv
 from config import load_config
 from datetime import datetime
+from PIL import Image
 
 load_dotenv()
 CONFIG = load_config()
@@ -19,11 +21,17 @@ MODELS = CONFIG["models"]
 VARIANTS = CONFIG["variants"]
 FIGMA_FILE_KEY = CONFIG["figma_file_key"]
 
-API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")
+API_BASE_URL = CONFIG["api_base_url"]
 FIGMA_API_TOKEN = os.getenv("FIGMA_API_TOKEN")
 HEADERS = {"X-Figma-Token": FIGMA_API_TOKEN}
+EXPORT_BASE_URL = "https://api.figma.com/v1"
 
-LOG_FILE = RESULTS_DIR / "experiment_log.txt"
+LOG_FILE = RESULTS_DIR / f"experiment_log_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+
+page = "Page 1"
+frame = None
+format = "png"
+scale = 1
 
 def log(message):
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -43,6 +51,13 @@ async def create_root_frame(session):
     params = {"x": 0, "y": 0, "width": 320, "height": 720, "name": "Frame"}
     async with session.post(f"{API_BASE_URL}/tool/create_root_frame", params=params) as res:
         return await res.json()
+
+async def get_document_info():
+    response = requests.post(f"{API_BASE_URL}/tool/get_document_info")
+    try:
+        return json.loads(response.json()["message"])
+    except:
+        return {}
 
 async def generate_variant(session, variant, model_name, image_path, meta_json):
     if "image" in variant:
@@ -72,42 +87,119 @@ async def generate_variant(session, variant, model_name, image_path, meta_json):
     async with session.post(f"{API_BASE_URL}/{endpoint}", data=data) as res:
         return await res.json()
 
-def fetch_node_export(json_response, step_count, root_frame_id, result_dir: Path, result_name: str):
-    node_id = root_frame_id
-    for attempt in range(2):
-        node_url = f"https://api.figma.com/v1/files/{FIGMA_FILE_KEY}/nodes?ids={node_id}"
-        try:
-            res = requests.get(node_url, headers=HEADERS)
-            if res.status_code == 200:
-                node_data = res.json()
-                with open(result_dir / f"{result_name}.json", "w", encoding="utf-8") as f:
-                    json.dump(node_data, f, indent=2, ensure_ascii=False)
 
-                thumbnail_url = node_data.get("thumbnailUrl")
-                if thumbnail_url:
-                    img_res = requests.get(thumbnail_url)
-                    if img_res.status_code == 200:
-                        with open(result_dir / f"{result_name}.png", "wb") as f:
-                            f.write(img_res.content)
-                break
-            else:
-                if attempt == 0:
-                    node_id = increment_node_id(node_id)
-                else:
-                    return
+def get_node_infos(file_key: str, page_name: str, frame_name: str = None, result_dir: Path = None, result_name: str = None):
+    url = f"{EXPORT_BASE_URL}/files/{file_key}"
+    res = requests.get(url, headers=HEADERS)
+    if res.status_code == 200:
+        node_data = res.json()
+        with open(result_dir / f"{result_name}.json", "w", encoding="utf-8") as f:
+            json.dump(node_data, f, indent=2, ensure_ascii=False)
 
-        except Exception as e:
-            log(f"[ERROR] Node export failed for {result_name}: {e}")
+    res.raise_for_status()
+    document = res.json()["document"]
 
-    with open(result_dir / f"{result_name}_json_response.json", "w", encoding="utf-8") as f:
+    page = next((c for c in document["children"] if c["name"] == page_name), None)
+    if not page:
+        raise ValueError(f"Page '{page_name}' not found")
+
+    targets = []
+
+    def recurse(nodes):
+        for node in nodes:
+            if "absoluteBoundingBox" in node:
+                targets.append({
+                    "id": node["id"],
+                    "name": re.sub(r"[^\w\-_]", "_", node["name"]),
+                    "bbox": node["absoluteBoundingBox"]
+                })
+            if "children" in node:
+                recurse(node["children"])
+
+    if frame_name:
+        frame = next((f for f in page["children"] if f["name"] == frame_name), None)
+        if not frame:
+            raise ValueError(f"Frame '{frame_name}' not found")
+        recurse(frame["children"])
+    else:
+        recurse(page["children"])
+
+    return targets  # List of dicts: id, name, bbox
+
+
+def export_images(file_key: str, node_infos: list, format: str = "png", out_dir: str = "exported_assets", scale: int = 1):
+    os.makedirs(out_dir, exist_ok=True)
+    ids = ",".join([n["id"] for n in node_infos])
+    url = f"{EXPORT_BASE_URL}/images/{file_key}?ids={ids}&format={format}&scale={scale}"
+    res = requests.get(url, headers=HEADERS)
+    res.raise_for_status()
+    images = res.json()["images"]
+
+    results = []
+    for node in node_infos:
+        node_id = node["id"]
+        name = node["name"]
+        if node_id not in images:
+            continue
+        img_url = images[node_id]
+        img_data = requests.get(img_url)
+        if img_data.status_code == 200:
+            file_path = Path(out_dir) / "assets" / f"{name}.{format}"
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            print(file_path)
+            with open(file_path, "wb") as f:
+                f.write(img_data.content)
+            results.append(str(file_path))
+    return results
+
+
+def render_combined_image(node_infos: list, img_urls: dict, out_path="combined_output.png", scale=1):
+    if not node_infos:
+        raise ValueError("No nodes provided for rendering.")
+
+    min_x = min(int(n["bbox"]["x"] * scale) for n in node_infos)
+    min_y = min(int(n["bbox"]["y"] * scale) for n in node_infos)
+    max_x = max(int((n["bbox"]["x"] + n["bbox"]["width"]) * scale) for n in node_infos)
+    max_y = max(int((n["bbox"]["y"] + n["bbox"]["height"]) * scale) for n in node_infos)
+
+    canvas_width = max_x - min_x
+    canvas_height = max_y - min_y
+    canvas = Image.new("RGBA", (canvas_width, canvas_height), (255, 255, 255, 0))
+
+    for node in node_infos:
+        node_id = node["id"]
+        if node_id not in img_urls:
+            continue
+        img_data = requests.get(img_urls[node_id])
+        if img_data.status_code == 200:
+            img = Image.open(io.BytesIO(img_data.content)).convert("RGBA")
+            x = int((node["bbox"]["x"] * scale) - min_x)
+            y = int((node["bbox"]["y"] * scale) - min_y)
+            canvas.paste(img, (x, y), img)
+
+    dir_name = os.path.dirname(out_path)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
+    canvas.save(out_path)
+
+def fetch_node_export(json_response, step_count, model_dir: Path, result_name: str):
+    output_dir = model_dir / result_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(output_dir / f"{result_name}_json_response.json", "w", encoding="utf-8") as f:
         json.dump(json_response, f, indent=2, ensure_ascii=False)
 
-    with open(result_dir / f"{result_name}_step_count.json", "w", encoding="utf-8") as f:
+    with open(output_dir / f"{result_name}_step_count.json", "w", encoding="utf-8") as f:
         json.dump({"step_count": step_count}, f, indent=2)
 
 async def run_experiment():
     async with aiohttp.ClientSession() as session:
         for model_name in MODELS:
+            log(f"[Figma File key]: {FIGMA_FILE_KEY}")
+            log(f"[MODELS]: {MODELS}")
+            log(f"[API_BASE_URL]: {API_BASE_URL}")
+            log(f"[VARIANTS]: {VARIANTS}")
+
             model_dir = RESULTS_DIR / model_name
             model_dir.mkdir(parents=True, exist_ok=True)
 
@@ -124,8 +216,8 @@ async def run_experiment():
 
                 for variant in VARIANTS:
                     result_name = f"{base_id}-{model_name}-{variant}"
-                    json_path = model_dir / f"{result_name}.json"
-                    png_path = model_dir / f"{result_name}.png"
+                    json_path = model_dir / result_name / f"{result_name}.json"
+                    png_path = model_dir / result_name / f"{result_name}.png"
                     if json_path.exists() and png_path.exists():
                         log(f"[SKIP] {result_name}")
                         print(f"[SKIP] {result_name}")
@@ -137,21 +229,42 @@ async def run_experiment():
                     in_progress_path.write_text(json.dumps(in_progress, indent=2, ensure_ascii=False), encoding='utf-8')
 
                     try:
-                        frame_gen_response = await create_root_frame(session)
-                        root_frame_id = frame_gen_response.get("root_frame_id")
-                        if not root_frame_id:
-                            log(f"[ERROR] Root frame creation failed for {result_name}")
-                            print(f"[ERROR] Root frame creation failed for {result_name}")
-                            continue
+                        # Check canvas is empty BEFORE generating
+                        document = await get_document_info()
+                        if document.get("children"):
+                            delete_url = f"{API_BASE_URL}/tool/delete_all_top_level_nodes"
+                            delete_response = requests.post(delete_url)
+                            if delete_response.status_code == 200:
+                                log(f"[CLEANUP] Deleted all top-level nodes before starting {result_name}")
+                                print(f"[CLEANUP] Deleted all top-level nodes before starting {result_name}")
 
                         response = await generate_variant(session, variant, model_name, image_path, meta_json)
+                        log(f"response: {response}")
+                        
                         fetch_node_export(
                             response["json_response"],
                             response["step_count"],
-                            root_frame_id,
                             model_dir,
                             result_name
                         )
+                        node_infos = get_node_infos(FIGMA_FILE_KEY, page_name=page, frame_name=frame, result_dir=model_dir, result_name=result_name)
+                        saved = export_images(FIGMA_FILE_KEY, node_infos, format=format, scale=scale, out_dir=model_dir / result_name)
+
+                        print("[Exported Files]")
+                        print("\n".join(saved))
+
+                        ids = ",".join([n["id"] for n in node_infos])
+                        url = f"{EXPORT_BASE_URL}/images/{FIGMA_FILE_KEY}?ids={ids}&format={format}&scale={scale}"
+                        img_res = requests.get(url, headers=HEADERS)
+                        img_res.raise_for_status()
+                        img_urls = img_res.json()["images"]
+
+                        combined_path = f"{model_dir}/{result_name}/{result_name}.png"
+                        render_combined_image(node_infos, img_urls, out_path=combined_path, scale=scale)
+                        print("✅ Combined image saved to:", combined_path)
+
+                        with open(model_dir / result_name / f"{result_name}_step_count.json", "w", encoding="utf-8") as f:
+                            json.dump({"step_count": response["step_count"]}, f, indent=2)
 
                         delete_url = f"{API_BASE_URL}/tool/delete_all_top_level_nodes"
                         delete_response = requests.post(delete_url)
@@ -165,14 +278,29 @@ async def run_experiment():
                             log(f"[CLEANUP-FAIL] Failed to delete nodes after {result_name}: {delete_response.status_code}")
                             print(f"[CLEANUP-FAIL] Failed to delete nodes after {result_name}: {delete_response.status_code}")
 
-
                     except Exception as e:
                         log(f"[ERROR] Failed {result_name}: {e}")
                         print(f"[ERROR] Failed {result_name}: {e}")
                         failures[result_name] = failures.get(result_name, 0) + 1
                         failures_path.write_text(json.dumps(failures, indent=2, ensure_ascii=False), encoding='utf-8')
+
+                        if 'response' in locals() and isinstance(response, dict):
+                            try:
+                                fetch_node_export(
+                                    response.get("json_response", {}),
+                                    response.get("step_count", -1),
+                                    model_dir,
+                                    result_name
+                                )
+                            except Exception as e_inner:
+                                log(f"[ERROR][SAVE-FAIL] Couldn't save partial response for {result_name}: {e_inner}")
+
                         delete_url = f"{API_BASE_URL}/tool/delete_all_top_level_nodes"
-                        requests.post(delete_url)
+                        delete_response = requests.post(delete_url)
+                        if delete_response.status_code == 200:
+                            log(f"[CLEANUP] Deleted all top-level nodes after failed {result_name}")
+                        else:
+                            log(f"[CLEANUP-FAIL] Failed to delete nodes after failed {result_name}: {delete_response.status_code}")
 
 if __name__ == "__main__":
     asyncio.run(run_experiment())

--- a/src/fastapi_server/app.py
+++ b/src/fastapi_server/app.py
@@ -29,6 +29,7 @@ async def lifespan_context():
 root_frame_id: Optional[str] = None
 root_frame_width: Optional[int] = None
 root_frame_height: Optional[int] = None
+current_channel: Optional[str] = None
 
 root_prompt_suffix = get_root_prompt_suffix(
     root_frame_id=root_frame_id,
@@ -242,6 +243,54 @@ async def delete_all_top_level_nodes():
     except Exception as e:
         import traceback
         traceback.print_exc()
+        return {"status": "error", "message": str(e)}
+
+@app.post("/tool/select_channel")
+async def select_channel_endpoint(
+    channel: Optional[str] = Query(None, description="The channel name to join. If not provided, will list available channels.")
+):
+    global current_channel
+    try:
+        # If channel is None, this will list available channels
+        result = await call_tool("select_channel", {"channel": channel} if channel else {})
+        
+        # Process the result to make it more user-friendly
+        if isinstance(result, dict) and "message" in result and result["message"]:
+            message = result["message"]
+            
+            # If response indicates successful channel join
+            if channel and "Successfully joined channel:" in message:
+                # Update server state to track current channel
+                current_channel = channel
+                return {
+                    "status": "success",
+                    "channel": current_channel
+                }
+            
+            # For channel listing, return a clean list
+            elif "Available channels:" in message:
+                
+                lines = message.strip().split('\n')
+                channels_text = lines[0].replace("Available channels:", "").strip()
+                
+                available_channels = [c.strip() for c in channels_text.split(',')]
+                
+
+                return {
+                    "status": "success",
+                    "available_channels": available_channels,
+                    "current_channel": current_channel
+                }
+            
+            # For errors or other responses
+            else:
+                return {
+                    "status": "error" if "Error" in message else "success",
+                    "message": message
+                }
+        
+        return {"status": "error", "message": "Invalid response from tool"}
+    except Exception as e:
         return {"status": "error", "message": str(e)}
 
 if __name__ == "__main__":

--- a/src/fastapi_server/figma_exporter.py
+++ b/src/fastapi_server/figma_exporter.py
@@ -1,0 +1,130 @@
+import os
+import re
+import io
+import json
+import requests
+from pathlib import Path
+from dotenv import load_dotenv
+from config import load_config
+from PIL import Image
+
+load_dotenv()
+CONFIG = load_config()
+
+FIGMA_API_TOKEN = os.getenv("FIGMA_API_TOKEN")
+FIGMA_FILE_KEY = CONFIG["figma_file_key"]
+HEADERS = {"X-Figma-Token": FIGMA_API_TOKEN}
+
+EXPORT_BASE_URL = "https://api.figma.com/v1"
+
+
+def get_node_infos(file_key: str, page_name: str, frame_name: str = None):
+    url = f"{EXPORT_BASE_URL}/files/{file_key}"
+    res = requests.get(url, headers=HEADERS)
+    res.raise_for_status()
+    document = res.json()["document"]
+
+    page = next((c for c in document["children"] if c["name"] == page_name), None)
+    if not page:
+        raise ValueError(f"Page '{page_name}' not found")
+
+    targets = []
+
+    def recurse(nodes):
+        for node in nodes:
+            if "absoluteBoundingBox" in node:
+                targets.append({
+                    "id": node["id"],
+                    "name": re.sub(r"[^\w\-_]", "_", node["name"]),
+                    "bbox": node["absoluteBoundingBox"]
+                })
+            if "children" in node:
+                recurse(node["children"])
+
+    if frame_name:
+        frame = next((f for f in page["children"] if f["name"] == frame_name), None)
+        if not frame:
+            raise ValueError(f"Frame '{frame_name}' not found")
+        recurse(frame["children"])
+    else:
+        recurse(page["children"])
+
+    return targets  # List of dicts: id, name, bbox
+
+
+def export_images(file_key: str, node_infos: list, format: str = "png", out_dir: str = "exported_assets", scale: int = 1):
+    os.makedirs(out_dir, exist_ok=True)
+    ids = ",".join([n["id"] for n in node_infos])
+    url = f"{EXPORT_BASE_URL}/images/{file_key}?ids={ids}&format={format}&scale={scale}"
+    res = requests.get(url, headers=HEADERS)
+    res.raise_for_status()
+    images = res.json()["images"]
+
+    results = []
+    for node in node_infos:
+        node_id = node["id"]
+        name = node["name"]
+        if node_id not in images:
+            continue
+        img_url = images[node_id]
+        img_data = requests.get(img_url)
+        if img_data.status_code == 200:
+            file_path = Path(out_dir) / f"{name}.{format}"
+            print(file_path)
+            with open(file_path, "wb") as f:
+                f.write(img_data.content)
+            results.append(str(file_path))
+    return results
+
+
+def render_combined_image(node_infos: list, img_urls: dict, out_path="combined_output.png", scale=1):
+    if not node_infos:
+        raise ValueError("No nodes provided for rendering.")
+
+    min_x = min(int(n["bbox"]["x"] * scale) for n in node_infos)
+    min_y = min(int(n["bbox"]["y"] * scale) for n in node_infos)
+    max_x = max(int((n["bbox"]["x"] + n["bbox"]["width"]) * scale) for n in node_infos)
+    max_y = max(int((n["bbox"]["y"] + n["bbox"]["height"]) * scale) for n in node_infos)
+
+    canvas_width = max_x - min_x
+    canvas_height = max_y - min_y
+    canvas = Image.new("RGBA", (canvas_width, canvas_height), (255, 255, 255, 0))
+
+    for node in node_infos:
+        node_id = node["id"]
+        if node_id not in img_urls:
+            continue
+        img_data = requests.get(img_urls[node_id])
+        if img_data.status_code == 200:
+            img = Image.open(io.BytesIO(img_data.content)).convert("RGBA")
+            x = int((node["bbox"]["x"] * scale) - min_x)
+            y = int((node["bbox"]["y"] * scale) - min_y)
+            canvas.paste(img, (x, y), img)
+
+    dir_name = os.path.dirname(out_path)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
+    canvas.save(out_path)
+
+
+if __name__ == "__main__":
+    page = "Page 1"
+    frame = None
+    format = "png"
+    scale = 1
+
+    node_infos = get_node_infos(FIGMA_FILE_KEY, page_name=page, frame_name=frame)
+    saved = export_images(FIGMA_FILE_KEY, node_infos, format=format, scale=scale)
+
+    print("[Exported Files]")
+    print("\n".join(saved))
+
+    ids = ",".join([n["id"] for n in node_infos])
+    url = f"{EXPORT_BASE_URL}/images/{FIGMA_FILE_KEY}?ids={ids}&format={format}&scale={scale}"
+    img_res = requests.get(url, headers=HEADERS)
+    img_res.raise_for_status()
+    img_urls = img_res.json()["images"]
+
+    combined_path = "combined_output.png"
+    render_combined_image(node_infos, img_urls, out_path=combined_path, scale=scale)
+    print("✅ Combined image saved to:", combined_path)

--- a/src/fastapi_server/prompts.py
+++ b/src/fastapi_server/prompts.py
@@ -53,16 +53,3 @@ Carefully examine the provided screen image and text, and precisely replicate th
 Please analyze the following text and screen image  and generate a UI inside the [ROOT FRAME] in the Figma canvas.
 {instruction}  
 """
-
-def get_root_prompt_suffix(root_frame_id: str, root_frame_width: int, root_frame_height: int) -> str:
-    return f"""
-
-[ROOT FRAME INFO]
-Every creation (e.g., text, rectangle, frame) should be contained in the ROOT FRAME in Figma.
-Find the ROOT FRAME in the Figma canvas using the ID.
-Match the creation size to the ROOT FRAME size.
-
-ROOT FRAME ID: {root_frame_id}
-ROOT FRAME Width: {root_frame_width}
-ROOT FRAME Height: {root_frame_height}
-"""

--- a/src/fastapi_server/requirements.txt
+++ b/src/fastapi_server/requirements.txt
@@ -1,95 +1,112 @@
-altair==5.5.0
-annotated-types==0.7.0
+aiohappyeyeballs @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_b38qlemj37/croot/aiohappyeyeballs_1734469403568/work
+aiohttp @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_44bhte2f2d/croot/aiohttp_1734692700992/work
+aiosignal @ file:///tmp/build/80754af9/aiosignal_1637843061372/work
+annotated-types @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_1fa2djihwb/croot/annotated-types_1709542925772/work
 anyio==4.9.0
-attrs==25.3.0
-blinker==1.9.0
+async-timeout @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_cfdah1hgvk/croot/async-timeout_1703097014863/work
+attrs @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_93pjmt0git/croot/attrs_1734533120523/work
+boto3 @ file:///home/conda/feedstock_root/build_artifacts/boto3_1746659620295/work
+botocore @ file:///home/conda/feedstock_root/build_artifacts/botocore_1746657880168/work
+Bottleneck==1.4.2
+Brotli @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_f7i0oxypt6/croot/brotli-split_1736182464088/work
 cachetools==5.5.2
-certifi==2025.1.31
-charset-normalizer==3.4.1
-click==8.1.8
-distro==1.9.0
-dnspython==2.7.0
-email_validator==2.2.0
-fastapi==0.115.12
-fastapi-cli==0.0.7
-gitdb==4.0.12
-GitPython==3.1.44
-h11==0.14.0
-httpcore==1.0.8
-httptools==0.6.4
+certifi @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_50bk79gkw_/croot/certifi_1745939223061/work/certifi
+cffi @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_e4xd9yd9i2/croot/cffi_1736182819442/work
+charset-normalizer @ file:///croot/charset-normalizer_1721748349566/work
+click @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_d2rtg2ejqc/croot/click_1744271604580/work
+distro @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_ddkyz0575y/croot/distro_1714488254309/work
+docstring_parser==0.16
+fastapi @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_89gzc8olly/croot/fastapi_1724789159605/work
+frozenlist @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_6eeg1bc_1e/croot/frozenlist_1730902809317/work
+google-api-core==2.24.2
+google-auth==2.40.1
+google-cloud-aiplatform==1.92.0
+google-cloud-bigquery==3.31.0
+google-cloud-core==2.4.3
+google-cloud-resource-manager==1.14.2
+google-cloud-storage==2.19.0
+google-crc32c==1.7.1
+google-genai==1.14.0
+google-resumable-media==2.7.2
+googleapis-common-protos==1.70.0
+greenlet @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_3fdrsxa1og/croot/greenlet_1733860082149/work
+grpc-google-iam-v1==0.14.2
+grpcio==1.72.0rc1
+grpcio-status==1.72.0rc1
+h11 @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_110bmw2coo/croot/h11_1706652289620/work
+httpcore @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_fcxiho9nv7/croot/httpcore_1706728465004/work
 httpx==0.28.1
-httpx-sse==0.4.0
-idna==3.10
-Jinja2==3.1.6
-jiter==0.9.0
-jsonpatch==1.33
-jsonpointer==3.0.0
-jsonschema==4.23.0
-jsonschema-specifications==2025.4.1
-langchain==0.3.23
-langchain-core==0.3.54
-langchain-mcp-adapters==0.0.9
-langchain-openai==0.3.14
-langchain-text-splitters==0.3.8
-langgraph==0.3.31
-langgraph-checkpoint==2.0.24
-langgraph-prebuilt==0.1.8
-langgraph-sdk==0.1.61
-langsmith==0.3.32
-markdown-it-py==3.0.0
-MarkupSafe==3.0.2
-mcp==1.6.0
-mdurl==0.1.2
-narwhals==1.38.0
-numpy==2.2.5
-openai==1.75.0
-orjson==3.10.16
-ormsgpack==1.9.1
-packaging==24.2
-pandas==2.2.3
-pillow==11.2.1
-protobuf==5.29.4
-pyarrow==20.0.0
-pydantic==2.11.3
-pydantic-settings==2.9.1
-pydantic_core==2.33.1
-pydeck==0.9.1
-Pygments==2.19.1
-python-dateutil==2.9.0.post0
-python-dotenv==1.1.0
-python-multipart==0.0.20
-pytz==2025.2
-PyYAML==6.0.2
-referencing==0.36.2
-regex==2024.11.6
-requests==2.32.3
-requests-toolbelt==1.0.0
-rich==14.0.0
-rich-toolkit==0.14.5
-rpds-py==0.24.0
-setuptools==80.3.1
-shellingham==1.5.4
-six==1.17.0
-smmap==5.0.2
-sniffio==1.3.1
-SQLAlchemy==2.0.40
-sse-starlette==2.2.1
-starlette==0.46.2
-streamlit==1.44.1
-tenacity==9.1.2
-tiktoken==0.9.0
-toml==0.10.2
-tornado==6.4.2
-tqdm==4.67.1
+httpx-sse @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_fbbwdbjprx/croot/httpx-sse_1734627589622/work
+idna @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_a12xpo84t2/croot/idna_1714398852854/work
+Jinja2 @ file:///home/conda/feedstock_root/build_artifacts/jinja2_1741263328855/work
+jiter @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_f4n0iuya3b/croot/jiter_1729808946806/work
+jmespath @ file:///Users/builder/cbouss/perseverance-python-buildout/croot/jmespath_1701804490553/work
+jsonpatch @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_3ajyoz8zoj/croot/jsonpatch_1714483362270/work
+jsonpointer==2.1
+langchain @ file:///home/conda/feedstock_root/build_artifacts/langchain_1746262321362/work
+langchain-aws @ file:///home/conda/feedstock_root/build_artifacts/langchain-aws_1745602586576/work
+langchain-core @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_57wre43v6y/croot/langchain-core_1746571809531/work/libs/core
+langchain-google-vertexai==2.0.22
+langchain-mcp-adapters==0.0.10
+langchain-openai @ file:///home/conda/feedstock_root/build_artifacts/langchain-openai_1746248132704/work
+langchain-text-splitters @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_b0lj0sg547/croot/langchain-text-splitters_1746641987628/work
+langgraph @ file:///home/conda/feedstock_root/build_artifacts/langgraph_1746590042403/work
+langgraph-checkpoint @ file:///home/conda/feedstock_root/build_artifacts/langgraph-checkpoint_1742285937817/work
+langgraph-prebuilt @ file:///home/conda/feedstock_root/build_artifacts/langgraph-prebuilt_1743747557261/work
+langgraph-sdk @ file:///home/conda/feedstock_root/build_artifacts/langgraph-sdk_1746062325339/work
+langsmith @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_10_x6mw56y/croot/langsmith_1746553422436/work/python
+markdown-it-py @ file:///Users/builder/cbouss/perseverance-python-buildout/croot/markdown-it-py_1699237863445/work
+MarkupSafe @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_1f_uj4vxik/croot/markupsafe_1738584045311/work
+mcp @ file:///home/conda/feedstock_root/build_artifacts/mcp_1746251952852/work
+mdurl @ file:///Users/builder/cbouss/perseverance-python-buildout/croot/mdurl_1699237660008/work
+msgpack @ file:///Users/runner/miniforge3/conda-bld/msgpack-python_1725975043881/work
+multidict @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_de95nfn702/croot/multidict_1730905502686/work
+numexpr==2.10.2
+numpy @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_a51i_mbs7m/croot/numpy_and_numpy_base_1708638620867/work/dist/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl#sha256=37afb6b734a197702d848df93bd67c10b52f6467d56e518950d84b6b1c949d27
+openai @ file:///home/conda/feedstock_root/build_artifacts/openai_1746266147758/work
+orjson @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_8f6hki8ldu/croot/orjson_1737039630134/work
+packaging @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_a6_qk3qyg7/croot/packaging_1734472142254/work
+propcache @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_a337s3hyzy/croot/propcache_1744012732470/work
+proto-plus==1.26.1
+protobuf==6.31.0rc2
+pyarrow==19.0.1
+pyasn1==0.6.1
+pyasn1_modules==0.4.2
+pycparser @ file:///tmp/build/80754af9/pycparser_1636541352034/work
+pydantic @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_4blmh3bau_/croot/pydantic_1734736077970/work
+pydantic-settings @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_85p3myg7l7/croot/pydantic-settings_1730800842854/work
+pydantic_core @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_bdqco4zmod/croot/pydantic-core_1734726070262/work
+Pygments @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_f0f10r98sf/croot/pygments_1744664126614/work
+PySocks @ file:///Users/builder/cbouss/perseverance-python-buildout/croot/pysocks_1699237568675/work
+python-dateutil @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_66ud1l42_h/croot/python-dateutil_1716495741162/work
+python-dotenv @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_0bqseadoho/croot/python-dotenv_1745610246418/work
+python-multipart @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_43t75u1qxn/croot/python-multipart_1743526711393/work
+PyYAML @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_faoex52hrr/croot/pyyaml_1728657970485/work
+regex @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_87pebw_aae/croot/regex_1736541331314/work
+requests @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_ee45nsd33z/croot/requests_1730999134038/work
+requests-toolbelt @ file:///Users/builder/cbouss/perseverance-python-buildout/croot/requests-toolbelt_1699238632371/work
+rich @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_034myiu7pr/croot/rich_1732638981241/work
+rsa==4.9.1
+s3transfer @ file:///home/conda/feedstock_root/build_artifacts/s3transfer_1745398507755/work
+setuptools==78.1.1
+shapely==2.1.0
+shellingham @ file:///Users/builder/cbouss/perseverance-python-buildout/croot/shellingham_1699238695807/work
+six @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_03myqm7p6o/croot/six_1744271511946/work
+sniffio @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_1573pknjrg/croot/sniffio_1705431298885/work
+SQLAlchemy @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_90cekltohb/croot/sqlalchemy_1745854526578/work
+sse-starlette @ file:///home/conda/feedstock_root/build_artifacts/sse-starlette_1722520017366/work
+starlette @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_21zxgkzlvl/croot/starlette-recipe_1724683207405/work
+tenacity @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_74aksf93nl/croot/tenacity_1730303583236/work
+tiktoken @ file:///Users/runner/miniforge3/conda-bld/tiktoken_1739550391739/work
+tqdm @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_5642tzrprr/croot/tqdm_1738943467095/work
 typer==0.15.3
-typing-inspection==0.4.0
-typing_extensions==4.13.2
-tzdata==2025.2
-urllib3==2.4.0
-uvicorn==0.34.2
-uvloop==0.21.0
-watchfiles==1.0.5
+typer-slim==0.15.3
+typing_extensions @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_0b3jpv_f79/croot/typing_extensions_1734714864260/work
+urllib3 @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_8dwi5l2dj0/croot/urllib3_1737133640453/work
+uvicorn @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_21sa_0zxyi/croot/uvicorn-split_1732661340579/work
+validators==0.35.0
 websockets==15.0.1
 wheel==0.45.1
-xxhash==3.5.0
-zstandard==0.23.0
+xxhash @ file:///private/var/folders/nz/j6p8yfhx1mv_0grj5xl4650h0000gp/T/abs_4dqzb3ngyc/croot/python-xxhash_1737039922516/work
+yarl @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_01an_nyy_6/croot/yarl_1732546853427/work
+zstandard @ file:///private/var/folders/k1/30mswbxs7r1g6zwn8y4fyt500000gp/T/abs_a5_i6g4o6n/croot/zstandard_1731356352787/work

--- a/src/fastapi_server/templates/index.html
+++ b/src/fastapi_server/templates/index.html
@@ -92,6 +92,26 @@
             padding: 16px;
             background-color: var(--color-canvas-default);
         }
+
+        .select-with-refresh {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .select-with-refresh select {
+            flex: 1;
+        }
+        
+        .button.small {
+            padding: 4px;
+            min-width: 30px;
+            height: 30px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 16px;
+        }
         
         /* Task type selector */
         .task-type-selector {
@@ -516,14 +536,17 @@
             <div class="debug-tool-panel">
                 <h3>Channel Selector</h3>
                 <div class="channel-selector">
-                    <div class="form-group">
+                    <div class="form-group channel-select-container">
                         <label for="channel-select">Current Channel: <span id="current-channel-display">None</span></label>
-                        <select id="channel-select" class="task-input">
-                            <option value="">Loading channels...</option>
-                        </select>
+                        <div class="select-with-refresh">
+                            <select id="channel-select" class="task-input">
+                                <option value="">Loading channels...</option>
+                            </select>
+                            <button id="refresh-channels" class="button small" title="Refresh Channels">
+                                ↻
+                            </button>
+                        </div>
                     </div>
-                    <button id="refresh-channels" class="button">Refresh Channels</button>
-                    <button id="join-channel" class="button primary">Join Channel</button>
                 </div>
             </div>
             
@@ -869,7 +892,7 @@
                 const button = document.getElementById('refresh-channels');
                 showLoading(button);
                 
-                const response = await fetch('/tool/select_channel', { method: 'POST' });
+                const response = await fetch('/tool/get_channels', { method: 'POST' });
                 
                 if (!response.ok) {
                     throw new Error(`Server error: ${response.status} ${response.statusText}`);
@@ -911,27 +934,23 @@
                     document.getElementById('tool-results').textContent = `Error fetching channels: ${data.message || 'Unknown error'}`;
                 }
                 
-                resetButton(button, 'Refresh Channels');
+                resetButton(button, '↻');
             } catch (error) {
                 document.getElementById('tool-results').textContent = `Error: ${error.message}`;
-                resetButton(document.getElementById('refresh-channels'), 'Refresh Channels');
+                resetButton(document.getElementById('refresh-channels'), '↻');
             }
         }
         
-        async function joinChannel() {
-            const channelSelect = document.getElementById('channel-select');
-            const selectedChannel = channelSelect.value;
-            
-            if (!selectedChannel) {
-                document.getElementById('tool-results').textContent = 'Please select a channel first.';
+        async function joinSelectedChannel(channelName) {
+            if (!channelName) {
                 return;
             }
             
             try {
-                const button = document.getElementById('join-channel');
-                showLoading(button);
+                // Show loading state in the display text
+                document.getElementById('current-channel-display').textContent = `Joining ${channelName}...`;
                 
-                const response = await fetch(`/tool/select_channel?channel=${encodeURIComponent(selectedChannel)}`, {
+                const response = await fetch(`/tool/select_channel?channel=${encodeURIComponent(channelName)}`, {
                     method: 'POST',
                 });
                 
@@ -943,23 +962,29 @@
                 log("Join channel response:", data);
                 
                 if (data.status === 'success') {
-                    document.getElementById('current-channel-display').textContent = data.channel || selectedChannel;
-                    document.getElementById('tool-results').textContent = `Successfully joined channel: ${data.channel || selectedChannel}`;
+                    document.getElementById('current-channel-display').textContent = data.channel || channelName;
+                    document.getElementById('tool-results').textContent = `Successfully joined channel: ${data.channel || channelName}`;
                 } else {
+                    document.getElementById('current-channel-display').textContent = 'Connection failed';
                     document.getElementById('tool-results').textContent = `Error joining channel: ${data.message || 'Unknown error'}`;
                 }
-                
-                resetButton(button, 'Join Channel');
             } catch (error) {
+                document.getElementById('current-channel-display').textContent = 'Connection error';
                 document.getElementById('tool-results').textContent = `Error: ${error.message}`;
-                resetButton(document.getElementById('join-channel'), 'Join Channel');
             }
         }
         
         // Event listeners for channel selector
+        // Refresh channels button
         document.getElementById('refresh-channels').addEventListener('click', fetchChannels);
-        document.getElementById('join-channel').addEventListener('click', joinChannel);
         
+        // Channel select change event - automatically join the selected channel
+        document.getElementById('channel-select').addEventListener('change', function() {
+            const selectedChannel = this.value;
+            if (selectedChannel) {
+                joinSelectedChannel(selectedChannel);
+            }
+        });
         // Initialize - fetch channels when page loads
         document.addEventListener('DOMContentLoaded', fetchChannels);
         

--- a/src/fastapi_server/templates/index.html
+++ b/src/fastapi_server/templates/index.html
@@ -329,6 +329,56 @@
             border-radius: 6px;
             margin-bottom: 16px;
         }
+
+        .debug-tool-panel {
+            padding: 16px;
+            background-color: var(--color-canvas-subtle);
+            border: 1px solid var(--color-border-default);
+            border-radius: 6px;
+            margin-bottom: 16px;
+        }
+        
+        .debug-tool-panel h3 {
+            margin-top: 0;
+            margin-bottom: 12px;
+            font-size: 16px;
+            font-weight: 500;
+        }
+        
+        .debug-tool-panel h4 {
+            margin-top: 12px;
+            margin-bottom: 8px;
+            font-size: 14px;
+            font-weight: 500;
+        }
+        
+        /* Channel selector styles */
+        .channel-selector {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        
+        .channel-selector .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+        
+        .channel-selector select {
+            width: 100%;
+            padding: 8px;
+        }
+        
+        .channel-selector .button-group {
+            display: flex;
+            gap: 8px;
+        }
+        
+        #current-channel-display {
+            font-weight: 600;
+            color: var(--color-accent-fg);
+        }
         
         .tool-buttons {
             display: flex;
@@ -460,8 +510,26 @@
         </div>
         
         <div class="sidebar-panel">
-            <div class="debug-tools">
-                <h2>Debug Tools</h2>
+            <h2>Debug Tools</h2>
+        
+            <!-- Channel Selector Panel -->
+            <div class="debug-tool-panel">
+                <h3>Channel Selector</h3>
+                <div class="channel-selector">
+                    <div class="form-group">
+                        <label for="channel-select">Current Channel: <span id="current-channel-display">None</span></label>
+                        <select id="channel-select" class="task-input">
+                            <option value="">Loading channels...</option>
+                        </select>
+                    </div>
+                    <button id="refresh-channels" class="button">Refresh Channels</button>
+                    <button id="join-channel" class="button primary">Join Channel</button>
+                </div>
+            </div>
+            
+            <!-- Node Manipulation Panel -->
+            <div class="debug-tool-panel">
+                <h3>Node Tools</h3>
                 <div class="tool-buttons">
                     <button id="get-selection" class="button">Get Selection</button>
                     <button id="create-frame" class="button">Create Root Frame</button>
@@ -469,7 +537,7 @@
                 </div>
                 
                 <div id="frame-params" style="display: none;">
-                    <h3>Create Frame Parameters</h3>
+                    <h4>Create Frame Parameters</h4>
                     <form id="frame-params-form" class="frame-params-form">
                         <div class="form-group">
                             <label for="frame-x">X:</label>
@@ -494,7 +562,11 @@
                         <button type="submit" class="button primary">Create</button>
                     </form>
                 </div>
-                
+            </div>
+            
+            <!-- Results Panel -->
+            <div class="debug-tool-panel">
+                <h3>Tool Results</h3>
                 <div id="tool-results" class="tool-result"></div>
             </div>
         </div>
@@ -791,6 +863,105 @@
                 });
             }
         }
+        
+        async function fetchChannels() {
+            try {
+                const button = document.getElementById('refresh-channels');
+                showLoading(button);
+                
+                const response = await fetch('/tool/select_channel', { method: 'POST' });
+                
+                if (!response.ok) {
+                    throw new Error(`Server error: ${response.status} ${response.statusText}`);
+                }
+                
+                const data = await response.json();
+                log("Channel list:", data);
+                
+                // Update channel dropdown
+                const channelSelect = document.getElementById('channel-select');
+                channelSelect.innerHTML = ''; // Clear options
+                
+                // Add a placeholder option
+                const placeholderOption = document.createElement('option');
+                placeholderOption.value = '';
+                placeholderOption.textContent = '-- Select a channel --';
+                channelSelect.appendChild(placeholderOption);
+                
+                // Add channel options
+                if (data.status === 'success' && data.available_channels) {
+                    data.available_channels.forEach(channel => {
+                        const option = document.createElement('option');
+                        option.value = channel;
+                        option.textContent = channel;
+                        channelSelect.appendChild(option);
+                    });
+                    
+                    // Update current channel display
+                    if (data.current_channel && data.current_channel !== 'None') {
+                        document.getElementById('current-channel-display').textContent = data.current_channel;
+                        // Select the current channel in dropdown
+                        Array.from(channelSelect.options).forEach(option => {
+                            if (option.value === data.current_channel) {
+                                option.selected = true;
+                            }
+                        });
+                    }
+                } else {
+                    document.getElementById('tool-results').textContent = `Error fetching channels: ${data.message || 'Unknown error'}`;
+                }
+                
+                resetButton(button, 'Refresh Channels');
+            } catch (error) {
+                document.getElementById('tool-results').textContent = `Error: ${error.message}`;
+                resetButton(document.getElementById('refresh-channels'), 'Refresh Channels');
+            }
+        }
+        
+        async function joinChannel() {
+            const channelSelect = document.getElementById('channel-select');
+            const selectedChannel = channelSelect.value;
+            
+            if (!selectedChannel) {
+                document.getElementById('tool-results').textContent = 'Please select a channel first.';
+                return;
+            }
+            
+            try {
+                const button = document.getElementById('join-channel');
+                showLoading(button);
+                
+                const response = await fetch(`/tool/select_channel?channel=${encodeURIComponent(selectedChannel)}`, {
+                    method: 'POST',
+                });
+                
+                if (!response.ok) {
+                    throw new Error(`Server error: ${response.status} ${response.statusText}`);
+                }
+                
+                const data = await response.json();
+                log("Join channel response:", data);
+                
+                if (data.status === 'success') {
+                    document.getElementById('current-channel-display').textContent = data.channel || selectedChannel;
+                    document.getElementById('tool-results').textContent = `Successfully joined channel: ${data.channel || selectedChannel}`;
+                } else {
+                    document.getElementById('tool-results').textContent = `Error joining channel: ${data.message || 'Unknown error'}`;
+                }
+                
+                resetButton(button, 'Join Channel');
+            } catch (error) {
+                document.getElementById('tool-results').textContent = `Error: ${error.message}`;
+                resetButton(document.getElementById('join-channel'), 'Join Channel');
+            }
+        }
+        
+        // Event listeners for channel selector
+        document.getElementById('refresh-channels').addEventListener('click', fetchChannels);
+        document.getElementById('join-channel').addEventListener('click', joinChannel);
+        
+        // Initialize - fetch channels when page loads
+        document.addEventListener('DOMContentLoaded', fetchChannels);
         
         // Task type selector
         document.querySelectorAll('.task-type-option').forEach(option => {

--- a/src/figma_mcp_plugin/ui.html
+++ b/src/figma_mcp_plugin/ui.html
@@ -166,6 +166,16 @@
             </button>
           </div>
         </div>
+
+        <div class="section">
+          <label for="channel-select">Channel</label>
+          <div style="display: flex; gap: 8px">
+            <select id="channel-select" style="flex-grow: 1; padding: 6px; background-color: #2d2d2d; color: #e0e0e0; border: 1px solid #444; border-radius: 4px;" disabled>
+              <option value="">Fetching channels...</option>
+            </select>
+          </div>
+        </div>
+        
         
         <div id="connection-status" class="status disconnected">
           Not connected to server
@@ -210,8 +220,11 @@
         pendingRequests: new Map(),
         logs: [],
         maxLogs: 500,
+        channels: [],
+        currentChannel: null,
+        joinedChannel: false
       };
-    
+
       // UI Elements
       const portInput = document.getElementById("port");
       const connectButton = document.getElementById("btn-connect");
@@ -221,6 +234,7 @@
       const logPanelTab = document.getElementById("log-panel-tab");
       const btnClearLogs = document.getElementById("btn-clear-logs");
       const btnClearLogsTab = document.getElementById("btn-clear-logs-tab");
+      const channelSelect = document.getElementById("channel-select");
     
       // Tabs
       const tabs = document.querySelectorAll(".tab");
@@ -232,6 +246,12 @@
       const progressMessage = document.getElementById("progress-message");
       const progressStatus = document.getElementById("progress-status");
       const progressPercentage = document.getElementById("progress-percentage");
+
+      // Channel select event listener
+      channelSelect.addEventListener("change", function() {
+        state.currentChannel = this.value;
+        joinChannel();
+      });
     
       // Initialize UI
       function updateConnectionStatus(isConnected, message) {
@@ -252,29 +272,39 @@
             updateConnectionStatus(true, "Already connected to server");
             return;
           }
-    
+      
           state.serverPort = port;
           state.socket = new WebSocket(`ws://localhost:${port}`);
-    
+      
           state.socket.onopen = () => {
-            state.socket.send(
-              JSON.stringify({
-                type: "join",
-                id: generateId()
-              })
-            );
+            state.connected = true;
+            updateConnectionStatus(true, `Connected to server on port ${port}. Fetching channels...`);
+            
+            // Request available channels
+            requestAvailableChannels();
           };
-    
+      
           state.socket.onmessage = (event) => {
             try {
               const data = JSON.parse(event.data);
               console.log("Received message:", data);
-    
+      
+              // Handle channel list response
+              if (data.type === "channels") {
+                handleChannelList(data.channels);
+                return;
+              }
+      
+              // Only process messages from the current channel if we've joined one
+              if (state.joinedChannel && data.channel && data.channel !== state.currentChannel) {
+                console.log(`Ignoring message from different channel: ${data.channel}`);
+                return;
+              }
+      
               if (data.type === "system") {
                 if (data.message && data.message.result) {
-                  state.connected = true;
                   updateConnectionStatus(true, `Connected to server on port ${port}`);
-    
+      
                   parent.postMessage(
                     {
                       pluginMessage: {
@@ -289,32 +319,156 @@
                 console.error("Error:", data.message);
                 updateConnectionStatus(false, `Error: ${data.message}`);
                 state.socket.close();
+              } else if (data.type === "join_result") {
+                if (data.success) {
+                  state.joinedChannel = true;
+                  updateConnectionStatus(true, `Connected on port ${port}, joined channel: ${state.currentChannel}`);
+                  
+                  addLogEntry({
+                    timestamp: new Date().toISOString(),
+                    direction: "system",
+                    type: "channel",
+                    data: `Successfully joined channel: ${state.currentChannel}`
+                  });
+                } else {
+                  addLogEntry({
+                    timestamp: new Date().toISOString(), 
+                    direction: "system",
+                    type: "error",
+                    data: `Failed to join channel: ${data.error || "Unknown error"}`
+                  });
+                }
+                return;
               }
-    
+      
               handleSocketMessage(data);
+              
+              // Add incoming message to log
+              addLogEntry({
+                timestamp: new Date().toISOString(),
+                direction: "incoming",
+                type: "websocket",
+                data: data
+              });
             } catch (error) {
               console.error("Error parsing message:", error);
             }
           };
-    
+      
           state.socket.onclose = () => {
             state.connected = false;
             state.socket = null;
+            state.joinedChannel = false;
+            state.currentChannel = null;
             updateConnectionStatus(false, "Disconnected from server");
+            updateChannelSelectUI(false);
           };
-    
+      
           state.socket.onerror = (error) => {
             console.error("WebSocket error:", error);
             updateConnectionStatus(false, "Connection error");
             state.connected = false;
             state.socket = null;
+            state.joinedChannel = false;
+            state.currentChannel = null;
+            updateChannelSelectUI(false);
           };
         } catch (error) {
           console.error("Connection error:", error);
           updateConnectionStatus(false, `Connection error: ${error.message || "Unknown error"}`);
         }
       }
-    
+
+      // Request available channels from the server
+      function requestAvailableChannels() {
+        if (!state.connected || !state.socket) {
+          console.error("Cannot request channels: socket not connected");
+          return;
+        }
+        
+        state.socket.send(
+          JSON.stringify({
+            type: "get_channels",
+            id: generateId()
+          })
+        );
+      }
+
+      // Handle received channel list
+      function handleChannelList(channels) {
+        if (!Array.isArray(channels) || channels.length === 0) {
+          addLogEntry({
+            timestamp: new Date().toISOString(),
+            direction: "system",
+            type: "warning",
+            data: "No channels available from server"
+          });
+          return;
+        }
+        
+        state.channels = channels;
+        
+        // Update channel dropdown
+        updateChannelSelectUI(true);
+        
+        // Automatically select the first channel
+        state.currentChannel = channels[0];
+        channelSelect.value = channels[0];
+        
+        // Automatically join the selected channel
+        joinChannel();
+      }
+
+      // Update channel select dropdown UI
+      function updateChannelSelectUI(enabled) {
+        channelSelect.disabled = !enabled;
+        
+        if (enabled && state.channels.length > 0) {
+          channelSelect.innerHTML = '';
+          state.channels.forEach(channel => {
+            const option = document.createElement('option');
+            option.value = channel;
+            option.textContent = channel;
+            if (channel === state.currentChannel) {
+              option.selected = true;
+            }
+            channelSelect.appendChild(option);
+          });
+        } else {
+          channelSelect.innerHTML = '<option value="">No channels available</option>';
+        }
+      }
+
+      // Join the selected channel
+      function joinChannel() {
+        if (!state.connected || !state.socket) {
+          console.error("Cannot join channel: socket not connected");
+          return;
+        }
+        
+        const channel = channelSelect.value;
+        if (!channel) {
+          console.error("No channel selected");
+          return;
+        }
+        
+        state.currentChannel = channel;
+        
+        state.socket.send(
+          JSON.stringify({
+            type: "join",
+            id: generateId(),
+            channel: state.currentChannel,
+            clientType: "figma_client"
+          })
+        );
+        
+        updateConnectionStatus(true, `Connected to server, joining channel: ${state.currentChannel}...`);
+      }
+
+
+
+
       // Disconnect from websocket server
       function disconnectFromServer() {
         if (state.socket) {
@@ -471,22 +625,29 @@
             reject(new Error("Not connected to server"));
             return;
           }
-    
+          
+          if (!state.joinedChannel) {
+            reject(new Error("Not joined to any channel"));
+            return;
+          }
+
           const id = generateId();
           state.pendingRequests.set(id, { resolve, reject });
-    
+
           state.socket.send(
             JSON.stringify({
               id,
               type: "message",
+              channel: state.currentChannel,
               message: {
                 id,
                 command,
                 params,
+                channel: state.currentChannel
               },
             })
           );
-    
+
           setTimeout(() => {
             if (state.pendingRequests.has(id)) {
               state.pendingRequests.delete(id);

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -1,15 +1,38 @@
 import { Server, ServerWebSocket } from "bun";
 
-// Store all connected clients
-const clients = new Set<ServerWebSocket<any>>();
+interface ClientInfo {
+  ws: ServerWebSocket<any>;
+  channel: string | null;
+  clientType: string;
+}
+
+// Store all connected clients with their metadata
+const clients = new Map<ServerWebSocket<any>, ClientInfo>();
+
+// Predefined list of available channels
+const availableChannels = [
+  "1_🐶_fluffy_puppy",
+  "2_🐱_playful_kitten",
+  "3_🐰_tiny_bunny",
+  "4_🦔cuddly_hedgehog",
+  "5_🐼_sleepy_panda",
+  "6_🐨_gentle_koala",
+  "7_🦁_curious_lion",
+  "8_🐧_lazy_penguin",
+  "9_🐬_soft_dolphin",
+  "10_🦦_happy_otter",
+];
 
 function handleConnection(ws: ServerWebSocket<any>) {
   console.log("New client connected");
 
-  // Add client to the set immediately
-  clients.add(ws);
+  // Add client to our map with default values
+  clients.set(ws, {
+    ws,
+    channel: null,
+    clientType: "unknown",
+  });
 
-  // Send welcome message to the new client
   ws.send(
     JSON.stringify({
       type: "system",
@@ -17,36 +40,48 @@ function handleConnection(ws: ServerWebSocket<any>) {
     })
   );
 
-  // Notify other clients
-  clients.forEach((client) => {
-    if (client !== ws && client.readyState === WebSocket.OPEN) {
-      client.send(
-        JSON.stringify({
-          type: "system",
-          message: "A new user has joined the chat",
-        })
-      );
-    }
-  });
-
   ws.close = () => {
-    console.log("Client disconnected");
+    console.log(
+      `Client disconnected (type: ${clients.get(ws)?.clientType || "unknown"})`
+    );
 
-    // Remove client from the set
+    // Get the client's channel before removing
+    const clientInfo = clients.get(ws);
+    const channel = clientInfo?.channel;
+
+    // Remove client from the map
     clients.delete(ws);
 
-    // Notify other clients
-    clients.forEach((client) => {
-      if (client.readyState === WebSocket.OPEN) {
-        client.send(
-          JSON.stringify({
-            type: "system",
-            message: "A user has left the chat",
-          })
-        );
-      }
-    });
+    // Notify other clients in the same channel
+    if (channel) {
+      broadcastToChannel(
+        channel,
+        {
+          type: "system",
+          channel: channel,
+          message: `A ${clientInfo?.clientType || "user"} has left the channel`,
+        },
+        ws
+      );
+    }
   };
+}
+
+// Broadcast message to all clients in a specific channel
+function broadcastToChannel(
+  channel: string,
+  message: any,
+  excludeClient?: ServerWebSocket<any>
+) {
+  for (const [_, clientInfo] of clients.entries()) {
+    if (
+      clientInfo.channel === channel &&
+      clientInfo.ws !== excludeClient &&
+      clientInfo.ws.readyState === WebSocket.OPEN
+    ) {
+      clientInfo.ws.send(JSON.stringify(message));
+    }
+  }
 }
 
 const server = Bun.serve({
@@ -89,48 +124,137 @@ const server = Bun.serve({
       try {
         console.log("Received message from client:", message);
         const data = JSON.parse(message as string);
+        const clientInfo = clients.get(ws);
 
-        // For backward compatibility, still accept join messages but simplify
-        if (data.type === "join") {
-          console.log("Sending message to client:", data.id);
-
+        // Handle get_channels request
+        if (data.type === "get_channels") {
+          console.log(
+            `Client requested channel list (type: ${
+              clientInfo?.clientType || "unknown"
+            })`
+          );
           ws.send(
             JSON.stringify({
-              type: "system",
-              message: {
-                id: data.id,
-                result: "Connected to chat server",
-              },
+              type: "channels",
+              id: data.id,
+              channels: availableChannels,
             })
           );
           return;
         }
 
-        // Handle regular messages
-        if (data.type === "message") {
-          // Broadcast to all clients
-          clients.forEach((client) => {
-            if (client.readyState === WebSocket.OPEN) {
-              console.log("Broadcasting message to client:", data.message);
-              client.send(
-                JSON.stringify({
-                  type: "broadcast",
-                  message: data.message,
-                  sender: client === ws ? "You" : "User",
-                })
+        // Handle join channel request
+        if (data.type === "join") {
+          const channel = data.channel;
+          const clientType = data.clientType || "unknown";
+
+          if (!availableChannels.includes(channel)) {
+            ws.send(
+              JSON.stringify({
+                type: "join_result",
+                success: false,
+                error: "Invalid channel",
+                channel: channel,
+              })
+            );
+            return;
+          }
+
+          // Update client info
+          if (clientInfo) {
+            const oldChannel = clientInfo.channel;
+            clientInfo.channel = channel;
+            clientInfo.clientType = clientType;
+
+            console.log(
+              `Client joined channel: ${channel} (type: ${clientType})`
+            );
+
+            // If leaving a previous channel, notify others in that channel
+            if (oldChannel && oldChannel !== channel) {
+              broadcastToChannel(
+                oldChannel,
+                {
+                  type: "system",
+                  channel: oldChannel,
+                  message: `A ${clientType} has left the channel`,
+                },
+                ws
               );
             }
+
+            // Notify others in the new channel
+            broadcastToChannel(
+              channel,
+              {
+                type: "system",
+                channel: channel,
+                message: `A ${clientType} has joined the channel`,
+              },
+              ws
+            );
+
+            // Send success response
+            ws.send(
+              JSON.stringify({
+                type: "join_result",
+                success: true,
+                channel: channel,
+              })
+            );
+          }
+          return;
+        }
+
+        // Handle regular messages - must have channel info
+        if (data.type === "message") {
+          const channel = data.channel || clientInfo?.channel;
+
+          if (!channel) {
+            ws.send(
+              JSON.stringify({
+                type: "error",
+                message: "No channel specified",
+              })
+            );
+            return;
+          }
+
+          console.log(
+            `Broadcasting message to channel: ${channel} (from: ${
+              clientInfo?.clientType || "unknown"
+            })`
+          );
+
+          // Add channel to the message if not already present
+          const message = data.message;
+          if (message && !message.channel) {
+            message.channel = channel;
+          }
+
+          // Broadcast only to clients in the same channel
+          broadcastToChannel(channel, {
+            type: "broadcast",
+            channel: channel,
+            message: message,
+            sender: clientInfo?.clientType || "unknown",
           });
         }
       } catch (err) {
         console.error("Error handling message:", err);
+        ws.send(
+          JSON.stringify({
+            type: "error",
+            message: "Error processing message",
+          })
+        );
       }
     },
     close(ws: ServerWebSocket<any>) {
-      // Remove client from set
-      clients.delete(ws);
+      // Client closing is handled in the handleConnection function
     },
   },
 });
 
 console.log(`WebSocket server running on port ${server.port}`);
+console.log(`Available channels: ${availableChannels.join(", ")}`);


### PR DESCRIPTION
- channel selection mechanism 생성
- socket.ts (소켓 서버) 가 channel list (10개 가량)을 들고 있고, 이를 figma client와 mcp client에게 분배함
- figma client는 selection 메뉴로 channel set
- mcp client는 fast_api server_state (app.py 내 전역변수) 로 channel name 관리하며 `/tool/select_channel` 과 `/tool/get_channels` 를 호출하여 채널명을 구하거나 채널 목록을 불러울 수 있음 (0.0.0.0:8080 내 UI에도 삽입)
- 동일 채널끼리만 메세지를 받을 수 있음
- 모든 통신은 단일 소켓 서버 (및 포트 3055)로 실행됨

## 이슈
- 코드 리팩토링 필요

<img width="709" alt="image" src="https://github.com/user-attachments/assets/503e43bf-e782-44e8-96cb-f5c4ae718c0a" />